### PR TITLE
[gia-si] Add Permission entity and Role-Permission mapping

### DIFF
--- a/aurora-backend/src/main/java/com/aurora/backend/entity/Permission.java
+++ b/aurora-backend/src/main/java/com/aurora/backend/entity/Permission.java
@@ -1,4 +1,24 @@
 package com.aurora.backend.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import java.util.Set;
+
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Entity @Table(name = "permissions")
 public class Permission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    String id;
+
+    @Column(nullable = false, unique = true)
+    String code;          // ví dụ: USER_READ, BOOKING_CREATE
+    String description;
+
+    @ManyToMany(mappedBy = "permissions", fetch = FetchType.LAZY)
+    @ToString.Exclude
+    Set<Role> roles;
 }

--- a/aurora-backend/src/main/java/com/aurora/backend/entity/Permission.java
+++ b/aurora-backend/src/main/java/com/aurora/backend/entity/Permission.java
@@ -1,0 +1,4 @@
+package com.aurora.backend.entity;
+
+public class Permission {
+}

--- a/aurora-backend/src/main/java/com/aurora/backend/entity/Role.java
+++ b/aurora-backend/src/main/java/com/aurora/backend/entity/Role.java
@@ -5,23 +5,26 @@ import lombok.*;
 import lombok.experimental.FieldDefaults;
 import java.util.Set;
 
-@Getter
-@Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-@Entity
+@Entity @Table(name = "roles")
 public class Role {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     String id;
 
     @Column(nullable = false, unique = true)
-    String name;
-
+    String name;          // ADMIN, STAFF, CUSTOMER
     String description;
 
-    @ManyToMany(mappedBy = "roles")
-    Set<User> users;
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "role_permissions",
+            joinColumns = @JoinColumn(name = "role_id"),
+            inverseJoinColumns = @JoinColumn(name = "permission_id"),
+            uniqueConstraints = @UniqueConstraint(columnNames = {"role_id","permission_id"})
+    )
+    @ToString.Exclude
+    Set<Permission> permissions;
 }


### PR DESCRIPTION
### Changes
- Add new `Permission` entity with UUID id
- Configure ManyToMany relationship:
  - `Role` ↔ `Permission`
  - Join table: `role_permissions`
- Ensure unique constraint on (role_id, permission_id)

### Notes
- Compatible with existing User-Role mapping
- No cascade applied to avoid unintended deletes
